### PR TITLE
Fix: handle empty strings and falsy values in template interpolation

### DIFF
--- a/packages/formatter/__tests__/interpolate.test.ts
+++ b/packages/formatter/__tests__/interpolate.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest'
+import { interpolate } from '../src/interpolate'
+
+describe('interpolate', () => {
+	test('replaces variables in message', () => {
+		expect(
+			interpolate({ message: 'Hello ${var}!', variables: ['world'] })
+		).toBe('Hello world!')
+	})
+
+	test('replaces multiple variables', () => {
+		expect(
+			interpolate({
+				message: '${var} has ${var} items',
+				variables: ['Cart', 5]
+			})
+		).toBe('Cart has 5 items')
+	})
+
+	test('empty string variables render as empty, not "null"', () => {
+		expect(
+			interpolate({
+				message: 'Searching workout history${var}...',
+				variables: ['']
+			})
+		).toBe('Searching workout history...')
+	})
+
+	test('zero renders as "0", not "null"', () => {
+		expect(interpolate({ message: 'Count: ${var}', variables: [0] })).toBe(
+			'Count: 0'
+		)
+	})
+
+	test('false renders as "false", not "null"', () => {
+		expect(interpolate({ message: 'Value: ${var}', variables: [false] })).toBe(
+			'Value: false'
+		)
+	})
+
+	test('null and undefined variables render as empty string', () => {
+		expect(
+			interpolate({ message: '${var} ${var}', variables: [null, undefined] })
+		).toBe(' ')
+	})
+})

--- a/packages/formatter/src/interpolate.tsx
+++ b/packages/formatter/src/interpolate.tsx
@@ -10,7 +10,7 @@ export function interpolate({ message, variables }: InterpolateProps) {
 		const variable = variables[index]
 		index++
 
-		if (!variable) return null
+		if (variable == null) return ''
 
 		return variable
 	})


### PR DESCRIPTION
## 📝 Description

Fixes a critical bug where empty string, zero, and false values interpolated in `ts` tagged templates render as the literal text "null" in the UI.

## ⛳️ Current behavior (updates)

When users interpolate empty strings or other falsy values:
```typescript
ts`Searching history${periodSuffix}...` // periodSuffix = ''
// Rendered as: "Searching historynull..."
```

The `interpolate()` function used `if (!variable)` (falsy check) and returned `null`, which JavaScript's `String.replace()` coerces to the literal string `"null"`.

## 🚀 New behavior

Changed the condition to `if (variable == null)` which only matches `null` and `undefined`, and returns empty string instead of null. Now:
- Empty strings (`''`) render as empty
- Zero (`0`) renders as `"0"`  
- Boolean `false` renders as `"false"`
- Missing variables (`null`/`undefined`) render as empty

## 💣 Is this a breaking change?

No. This is a bugfix. Users who applied workarounds can simplify their code.

## 📝 Additional Information

- Added 6 comprehensive tests in `packages/formatter/__tests__/interpolate.test.ts`
- All existing tests continue to pass
- Root cause: `packages/formatter/src/interpolate.tsx:13`

Fixes issue where users had to work around this with conditional template strings instead of interpolating empty values directly.